### PR TITLE
Use newer openjdk@8 specification for JDK 1.8

### DIFF
--- a/coursier.rb
+++ b/coursier.rb
@@ -10,7 +10,7 @@ class Coursier < Formula
 
   option "without-zsh-completions", "Disable zsh completion installation"
 
-  depends_on :java => "1.8+"
+  depends_on "openjdk@8"
 
   def install
     unless build.without? "zsh-completion"


### PR DESCRIPTION
In reaction to

> Warning: Calling depends_on :java is deprecated! Use depends_on "openjdk@11", depends_on "openjdk@8" or depends_on "openjdk" instead.